### PR TITLE
automatically build 'dist' code before publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+src

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "NODE=production node ./dist/index",
     "dev": "./node_modules/.bin/babel-watch ./src/index",
     "lint": "./node_modules/.bin/eslint src",
-    "build": "./node_modules/.bin/babel src -d dist"
+    "build": "./node_modules/.bin/babel src -d dist",
+    "prepublish": "npm run build"
   },
   "author": "Max Nowack <max@unsou.de>",
   "license": "MIT",


### PR DESCRIPTION
With this patch npm always runs `npm run build` to build `dist` code before publishing to npm. The `src` dir will be ignored by npm.