### PR TITLE
fix license mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublish": "npm run build"
   },
   "author": "Max Nowack <max@unsou.de>",
-  "license": "MIT",
+  "license": "GPLv3",
   "keywords": [
     "bluetooth",
     "thermostat",


### PR DESCRIPTION
According to `README.md` and `LICENCE` the code is available under GPLv3. This patch updates `package.json` to reflect that.